### PR TITLE
Feature/crlf fix sl

### DIFF
--- a/src/sass/tokenizer.js
+++ b/src/sass/tokenizer.js
@@ -341,12 +341,31 @@ module.exports = function(css, tabSize) {
 
       // If current character is a punctuation mark:
       else if (c in Punctuation) {
-        // Add it to the list of tokens:
-        pushToken(Punctuation[c], c, col);
-        if (c === '\n' || c === '\r') {
-          ln++;
-          col = 0;
-        } // Go to next line
+        // Check for CRLF here or just LF
+        if (c === '\r' && cn === '\n' || c === '\n') {
+          /*
+           * If \r we know the next character is \n due to statement above
+           * so we push a CRLF token type to the token list and importantly
+           * skip the next character so as not to double count newlines or
+           * columns etc
+           */
+          if (c === '\r') {
+            pushToken(TokenType.Newline, '\r\n', col);
+            pos++; // If crlf skip the next character and push crlf token
+          } else if (c === '\n') {
+            /*
+             * If just a Lf newline and not part of CRLF newline we can just
+             * push punctuation as usual
+             */
+            pushToken(Punctuation[c], c, col);
+          }
+
+          ln++; // Go to next line
+          col = 0; // Reset the column count
+        } else if (c !== '\r' && c !== '\n') {
+          // Handle all other punctuation and add to list of tokens
+          pushToken(Punctuation[c], c, col);
+        }// Go to next line
         if (c === ')') urlMode = false; // Exit url mode
         if (c === '{') blockMode++; // Enter a block
         if (c === '}') blockMode--; // Exit a block

--- a/src/scss/tokenizer.js
+++ b/src/scss/tokenizer.js
@@ -279,12 +279,31 @@ module.exports = function(css, tabSize) {
 
       // If current character is a punctuation mark:
       else if (c in Punctuation) {
-        // Add it to the list of tokens:
-        pushToken(Punctuation[c], c, col);
-        if (c === '\n' || c === '\r') {
-          ln++;
-          col = 0;
-        } // Go to next line
+        // Check for CRLF here or just LF
+        if (c === '\r' && cn === '\n' || c === '\n') {
+          /*
+           * If \r we know the next character is \n due to statement above
+           * so we push a CRLF token type to the token list and importantly
+           * skip the next character so as not to double count newlines or
+           * columns etc
+           */
+          if (c === '\r') {
+            pushToken(TokenType.Newline, '\r\n', col);
+            pos++; // If crlf skip the next character and push crlf token
+          } else if (c === '\n') {
+            /*
+             * If just a Lf newline and not part of CRLF newline we can just
+             * push punctuation as usual
+             */
+            pushToken(Punctuation[c], c, col);
+          }
+
+          ln++; // Go to next line
+          col = 0; // Reset the column count
+        } else if (c !== '\r' && c !== '\n') {
+          // Handle all other punctuation and add to list of tokens
+          pushToken(Punctuation[c], c, col);
+        }// Go to next line
         if (c === ')') urlMode = false; // Exit url mode
         if (c === '{') blockMode++; // Enter a block
         if (c === '}') blockMode--; // Exit a block

--- a/test/sass/ruleset/test.coffee
+++ b/test/sass/ruleset/test.coffee
@@ -13,6 +13,8 @@ describe 'sass/ruleset >>', ->
 
   it 'color.ident.0', -> this.shouldBeOk()
   it 'color.ident.1', -> this.shouldBeOk()
+  it 'issue-119-1', -> this.shouldBeOk()
+  it 'issue-119-2', -> this.shouldBeOk()
 
   it 's.0', -> this.shouldBeOk()
   it 's.1', -> this.shouldBeOk()

--- a/test/sass/stylesheet/crlf/0.json
+++ b/test/sass/stylesheet/crlf/0.json
@@ -1,0 +1,203 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "id",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "test",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 5
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "space",
+          "content": "\r\n",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 1
+              },
+              "end": {
+                "line": 2,
+                "column": 2
+              }
+            },
+            {
+              "type": "declaration",
+              "content": [
+                {
+                  "type": "property",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "color",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 7
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 7
+                  }
+                },
+                {
+                  "type": "propertyDelimiter",
+                  "content": ":",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "value",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "red",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 12
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 12
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 12
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 12
+  }
+}

--- a/test/sass/stylesheet/crlf/0.sass
+++ b/test/sass/stylesheet/crlf/0.sass
@@ -1,0 +1,2 @@
+#test
+  color: red

--- a/test/sass/stylesheet/crlf/issue152.json
+++ b/test/sass/stylesheet/crlf/issue152.json
@@ -1,0 +1,203 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "class",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "    ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 1
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            {
+              "type": "declaration",
+              "content": [
+                {
+                  "type": "property",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "color",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "propertyDelimiter",
+                  "content": ":",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                {
+                  "type": "value",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "red",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 14
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 14
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 14
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 14
+  }
+}

--- a/test/sass/stylesheet/crlf/issue152.sass
+++ b/test/sass/stylesheet/crlf/issue152.sass
@@ -1,0 +1,2 @@
+.foo
+    color: red

--- a/test/sass/stylesheet/test.coffee
+++ b/test/sass/stylesheet/test.coffee
@@ -21,3 +21,5 @@ describe 'sass/stylesheet >>', ->
   it 's.1', -> this.shouldBeOk()
   it 's.2', -> this.shouldBeOk()
   it 's.3', -> this.shouldBeOk()
+
+  it 'crlf/0', -> this.shouldBeOk()

--- a/test/sass/stylesheet/test.coffee
+++ b/test/sass/stylesheet/test.coffee
@@ -23,3 +23,4 @@ describe 'sass/stylesheet >>', ->
   it 's.3', -> this.shouldBeOk()
 
   it 'crlf/0', -> this.shouldBeOk()
+  it 'crlf/issue152', -> this.shouldBeOk()

--- a/test/scss/stylesheet/crlf/0.json
+++ b/test/scss/stylesheet/crlf/0.json
@@ -1,0 +1,229 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "id",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "test",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 5
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 1,
+            "column": 6
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "\r\n  ",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 2,
+                "column": 2
+              }
+            },
+            {
+              "type": "declaration",
+              "content": [
+                {
+                  "type": "property",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "color",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 7
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 7
+                  }
+                },
+                {
+                  "type": "propertyDelimiter",
+                  "content": ":",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "value",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "red",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 12
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "declarationDelimiter",
+              "content": ";",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "space",
+              "content": "\r\n",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 15
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 1
+  }
+}

--- a/test/scss/stylesheet/crlf/0.scss
+++ b/test/scss/stylesheet/crlf/0.scss
@@ -1,0 +1,3 @@
+#test {
+  color: red;
+}

--- a/test/scss/stylesheet/crlf/issue152.json
+++ b/test/scss/stylesheet/crlf/issue152.json
@@ -1,0 +1,229 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "class",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "\n    ",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            {
+              "type": "declaration",
+              "content": [
+                {
+                  "type": "property",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "color",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "propertyDelimiter",
+                  "content": ":",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                {
+                  "type": "value",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "red",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 14
+              }
+            },
+            {
+              "type": "declarationDelimiter",
+              "content": ";",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 15
+              },
+              "end": {
+                "line": 2,
+                "column": 15
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 16
+              },
+              "end": {
+                "line": 2,
+                "column": 16
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 1
+  }
+}

--- a/test/scss/stylesheet/crlf/issue152.scss
+++ b/test/scss/stylesheet/crlf/issue152.scss
@@ -1,0 +1,3 @@
+.foo {
+    color: red;
+}

--- a/test/scss/stylesheet/test.coffee
+++ b/test/scss/stylesheet/test.coffee
@@ -9,3 +9,4 @@ describe 'scss/stylesheet >>', ->
   it 'issue104', -> this.shouldBeOk()
 
   it 'crlf/0', -> this.shouldBeOk()
+  it 'crlf/issue152', -> this.shouldBeOk()

--- a/test/scss/stylesheet/test.coffee
+++ b/test/scss/stylesheet/test.coffee
@@ -7,3 +7,5 @@ describe 'scss/stylesheet >>', ->
   it 'issue-95', -> this.shouldBeOk()
   it 'issue-95.test-2', -> this.shouldBeOk()
   it 'issue104', -> this.shouldBeOk()
+
+  it 'crlf/0', -> this.shouldBeOk()


### PR DESCRIPTION
Fixes the CRLF parsing in Gonzales-pe. Confirmed working with all the sass-lint tests with CRLF line endings.

There's also a PR into Gonzales-pe base via [162](https://github.com/tonyganch/gonzales-pe/pull/162)
